### PR TITLE
Don't store node names as a joined string

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -643,7 +643,7 @@ type ParserSpec = {
   states: string | Uint32Array,
   stateData: string | Uint16Array,
   goto: string | Uint16Array,
-  nodeNames: string,
+  nodeNames: string[],
   maxTerm: number,
   repeatNodeCount: number,
   nodeProps?: [NodeProp<any>, ...(string | number)[]][],
@@ -754,7 +754,7 @@ export class Parser {
     if (spec.version != File.Version)
       throw new RangeError(`Parser version (${spec.version}) doesn't match runtime version (${File.Version})`)
     let tokenArray = decodeArray<Uint16Array>(spec.tokenData)
-    let nodeNames = spec.nodeNames.split(" ")
+    let nodeNames = spec.nodeNames
     this.minRepeatTerm = nodeNames.length
     this.context = spec.context
     for (let i = 0; i < spec.repeatNodeCount; i++) nodeNames.push("")


### PR DESCRIPTION
This handles the change in https://github.com/lezer-parser/lezer-generator/pull/6