### PR TITLE
Fix @internal annotation for Stack.useNode

### DIFF
--- a/src/stack.ts
+++ b/src/stack.ts
@@ -185,7 +185,8 @@ export class Stack {
     else this.shift(action, next, nextEnd)
   }
 
-  // Add a prebuilt (reused) node into the buffer. @internal
+  // Add a prebuilt (reused) node into the buffer.
+  /// @internal
   useNode(value: Tree, next: number) {
     let index = this.p.reused.length - 1
     if (index < 0 || this.p.reused[index] != value) {


### PR DESCRIPTION
The website's reference documentation currently includes `Stack.useNode` despite it being marked as internal

![image](https://user-images.githubusercontent.com/6740947/145727364-a828c457-1bf4-4e8d-85f1-1336fcf77f01.png)
