### PR TITLE
Fix: process.env may not exist

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,7 @@ import {Tokenizer, TokenGroup, ExternalTokenizer, CachedToken, InputStream} from
 import {decodeArray} from "./decode"
 
 // Environment variable used to control console output
-const verbose = typeof process != "undefined" && /\bparse\b/.test(process.env.LOG!)
+const verbose = typeof process?.env != "undefined" && /\bparse\b/.test(process.env.LOG!)
 
 let stackIDs: WeakMap<Stack, string> | null = null
 


### PR DESCRIPTION
Sometimes `process != 'undefined'` but `process.env == undefined`,in a framework [Nuxt3](https://v3.nuxtjs.org/). Like this: 

![image](https://user-images.githubusercontent.com/45785585/166640979-8caec153-5047-4829-b7e5-4d1a4090efa4.png)

Error:
![image](https://user-images.githubusercontent.com/45785585/166641661-ae985aca-fc8f-42fb-abf1-1369af5874b8.png)


Anyhow,maybe we should check whether `env` exists in this place.