### PR TITLE
Export the enums from the main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "scripts": {
     "test": "echo 'Tests are in @lezer/generator'",
     "watch": "node build.js --watch",
-    "prepare": "node build.js; tsc src/constants.ts -d --outDir dist"
+    "prepare": "node build.js"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@
 // The value 0 (which is not a valid action because no shift goes to
 // state 0, the start state), is often used to denote the absence of a
 // valid action.
-export const enum Action {
+export enum Action {
   // Distinguishes between shift (off) and reduce (on) actions.
   ReduceFlag = 1 << 16,
   // The first 16 bits hold the target state's id for shift actions,
@@ -43,7 +43,7 @@ export const enum Action {
 }
 
 // Each parser state has a `flags` field.
-export const enum StateFlag {
+export enum StateFlag {
   // Set if this state is part of a skip expression (which means nodes
   // produced by it should be moved out of any node reduced directly
   // after them).
@@ -56,19 +56,19 @@ export const enum StateFlag {
 // indicate whether this specialization replaced the original token
 // (`Specialize`) or adds a second interpretation while also leaving
 // the first (`Extend`).
-export const enum Specialize {
+export enum Specialize {
   Specialize = 0,
   Extend = 1
 }
 
 // Terms are 16-bit numbers
-export const enum Term {
+export enum Term {
   // The value of the error term is hard coded, the others are
   // allocated per grammar.
   Err = 0
 }
 
-export const enum Seq {
+export enum Seq {
   // Used as end marker for most of the sequences stored in uint16
   // arrays
   End = 0xffff,
@@ -78,7 +78,7 @@ export const enum Seq {
 }
 
 // Memory layout of parse states
-export const enum ParseState {
+export enum ParseState {
   // Offsets into the record of the individual fields
   Flags = 0,
   Actions = 1,
@@ -90,7 +90,7 @@ export const enum ParseState {
   Size = 6
 }
 
-export const enum Encode {
+export enum Encode {
   BigValCode = 126,
   BigVal = 0xffff,
   Start = 32,
@@ -99,6 +99,6 @@ export const enum Encode {
   Base = 46 // (126 - 32 - 2) / 2
 }
 
-export const enum File {
+export enum File {
   Version = 14
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export {LRParser, ParserConfig, ContextTracker} from "./parse"
 export {InputStream, ExternalTokenizer, LocalTokenGroup} from "./token"
 export {Stack} from "./stack"
+export {Action, Encode, File, ParseState, Seq, Specialize, StateFlag, Term} from "./constants"


### PR DESCRIPTION
Previously, the enums were exported from an additional file, `./dist/constants`, which was a problem for some bundlers like esbuild because the `./dist/constants` entrypoint isn't declared in the package.json. After reexporting them from the main entrypoint I found out that it still didn't work right because esbuild can't inline const enums across packages (and frankly, I wouldn't expect it to). Thus, I've changed enums to regular ones and exported them from the index, and now the generator package builds correctly with my PR for Unplugin